### PR TITLE
fix: integration test velocity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .devenv
 .pre-commit-config.yaml
+*.log
 out/

--- a/flake.nix
+++ b/flake.nix
@@ -141,7 +141,7 @@
             };
             processComposeConfigFile = pkgs.writeText "SanitasProcessComposeConfig.yaml" (pkgs.lib.generators.toYAML {} processComposeConfig);
           in ''
-            cat ${processComposeConfigFile}
+            echo ${processComposeConfigFile}
             process-compose -f ${processComposeConfigFile}
           '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -137,7 +137,7 @@
 
             processComposeConfig = {
               version = "0.5";
-              # is_tui_disabled = true;
+              is_tui_disabled = true;
               log_location = "./integration_tests.log";
               processes = {
                 DB = {

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,7 @@
               ipCommand =
                 if builtins.elem system ["x86_64-darwin" "aarch64-darwin"]
                 then "ifconfig en0 | grep 'inet ' | cut -d' ' -f2"
-                else "ip route get 1.2.3.4 | awk '{print $7}'";
+                else "ip route get 1.2.3.4 | cut -d' ' -f7";
             in ''
               set -euo pipefail
               cd sanitas_backend/

--- a/flake.nix
+++ b/flake.nix
@@ -70,15 +70,15 @@
               set -euo pipefail
               cd sanitas_backend/
 
-              echo Starting backend
-              echo Getting ifconfig
-              ifconfig en0
-              echo Grepping for inet
-              ifconfig en0 | grep 'inet '
-              echo Using AWK
-              awk --version
-              echo -e "ifconfig en0 | grep 'inet ' | cut -d' ' -f2"
-              ifconfig en0 | grep 'inet ' | cut -d' ' -f2
+              # echo Starting backend
+              # echo Getting ifconfig
+              # ifconfig en0
+              # echo Grepping for inet
+              # ifconfig en0 | grep 'inet '
+              # echo Using AWK
+              # awk --version
+              # echo -e "ifconfig en0 | grep 'inet ' | cut -d' ' -f2"
+              # ifconfig en0 | grep 'inet ' | cut -d' ' -f2
 
               echo Building backend
               sam build


### PR DESCRIPTION
# Jira

[Link al issue en Jira](Link%20al%20clickup)

## Descripción

Esta PR mejora la velocidad de las tests de integración creando flow con `process-compose`. Los tests deberían correr ahora en poco mas de 2-3mins en el CI.

Para probar el comando por favor ejecutar:
```
nix run .#integrationTests
```

como si se estuviera ejecutando el `restartServices` solamente que es `integrationTests`.

## Tasks

<!-- Asegúrate de cumplir todas estas tareas antes de hacer la PR. -->

- \[x] Asignate a tí mismo dentro de la PR.
- \[x] Asegúrate que el nombre de la PR siga el formato de [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- \[x] Añade una breve descripción de la escencia de tus cambios en tu PR.
- \[x] Agrega el link al issue de Jira.
- \[x] Asegurate que la PR pase todos los chequeos de CI.
- \[x] Ponle las tags correspondientes a tu PR.
  Backend: PRs que modifican lógica relacionada al backend.
  Frontend: PRs que modifican lógica relacionada al frontend.
  Database: PRs que modifican lógica relacionada a la base de datos.
  Wiki: PRs que editan la wiki.
  Nix: PRs que modifican el entorno de desarrollo en Nix.
  CI/CD: PRs relacionadas con la CI/CD pipeline.
